### PR TITLE
build: add conanfile

### DIFF
--- a/conanfile_rtc.py
+++ b/conanfile_rtc.py
@@ -1,0 +1,25 @@
+from conans import ConanFile
+
+
+class GTestParallelConan(ConanFile):
+    name = "gtest-parallel"
+    version = "11cce5c2872be4849c087afc7d19fbed390fa928" # commit hash
+    url = "https://github.com/Esri/gtest-parallel/tree/runtimecore"
+    license = "https://github.com/Esri/gtest-parallel/blob/runtimecore/LICENSE"
+    description = (
+        "gtest-parallel is a script that executes Google Test binaries in parallel"
+    )
+
+    # Use the OS default to get the right line endings
+    settings = "os"
+
+    def package(self):
+        base = self.source_folder + "/"
+        relative = "3rdparty/gtest-parallel/"
+
+        # transfer scripts 
+        self.copy("gtest-parallel", src=base, dst=relative)
+        self.copy("gtest_parallel.py", src=base, dst=relative)
+
+    def package_id(self):
+        self.info.header_only()


### PR DESCRIPTION
First pass at creating a `conanfile` for `gtest-parallel`. 

Because `gtest-parallel` doesn't have a version per se, I used the most recent commit hash in `runtimecore` (before this addition, I suppose). Not sure if that's the correct solution here.