### PR TITLE
conan: Remove header only

### DIFF
--- a/conanfile_rtc.py
+++ b/conanfile_rtc.py
@@ -3,12 +3,10 @@ from conans import ConanFile
 
 class GTestParallelConan(ConanFile):
     name = "gtest-parallel"
-    version = "11cce5c2872be4849c087afc7d19fbed390fa928" # commit hash
+    version = "11cce5c2872be4849c087afc7d19fbed390fa928"  # commit hash
     url = "https://github.com/Esri/gtest-parallel/tree/runtimecore"
     license = "https://github.com/Esri/gtest-parallel/blob/runtimecore/LICENSE"
-    description = (
-        "gtest-parallel is a script that executes Google Test binaries in parallel"
-    )
+    description = "gtest-parallel is a script that executes Google Test binaries in parallel"
 
     # Use the OS default to get the right line endings
     settings = "os"
@@ -17,9 +15,6 @@ class GTestParallelConan(ConanFile):
         base = self.source_folder + "/"
         relative = "3rdparty/gtest-parallel/"
 
-        # transfer scripts 
+        # transfer scripts
         self.copy("gtest-parallel", src=base, dst=relative)
         self.copy("gtest_parallel.py", src=base, dst=relative)
-
-    def package_id(self):
-        self.info.header_only()


### PR DESCRIPTION
Issue-number: https://devtopia.esri.com/runtime/devops/issues/694

Using header only actually invalidates all settings. These settings are
useful for executable permissions and line endings.