### PR TITLE
gtest-parallel: Update command-line arguments

### DIFF
--- a/gtest_parallel.py
+++ b/gtest_parallel.py
@@ -579,7 +579,8 @@ def find_tests(binaries, additional_args, options, times):
     list_command = command + ['--gtest_list_tests']
     if options.test != '':
       list_command += ['--test=' + options.test]
-
+    if options.gtest_filter != '':
+      list_command += ['--gtest_filter=' + options.gtest_filter]
     if options.size != '':
       list_command += ['--size=' + options.size]
 
@@ -710,6 +711,8 @@ def default_options_parser():
                     help='number of workers to spawn')
   parser.add_option('--gtest_color', type='string', default='yes',
                     help='color output')
+  parser.add_option('--gtest_filter', type='string', default='',
+                    help='test filter')
   parser.add_option('--test', type='string', default='',
                     help='select a specific test or tests to run')
   parser.add_option('--size', type='string', default='', 

--- a/gtest_parallel.py
+++ b/gtest_parallel.py
@@ -577,8 +577,8 @@ def find_tests(binaries, additional_args, options, times):
       command += ['--gtest_also_run_disabled_tests']
 
     list_command = command + ['--gtest_list_tests']
-    if options.gtest_filter != '':
-      list_command += ['--gtest_filter=' + options.gtest_filter]
+    if options.test != '':
+      list_command += ['--test=' + options.test]
 
     if options.size != '':
       list_command += ['--size=' + options.size]
@@ -710,8 +710,8 @@ def default_options_parser():
                     help='number of workers to spawn')
   parser.add_option('--gtest_color', type='string', default='yes',
                     help='color output')
-  parser.add_option('--gtest_filter', type='string', default='',
-                    help='test filter')
+  parser.add_option('--test', type='string', default='',
+                    help='select a specific test or tests to run')
   parser.add_option('--size', type='string', default='', 
                     help='select a test size (S, M, L, XL, *) to run')
   parser.add_option('--gtest_also_run_disabled_tests', action='store_true',

--- a/gtest_parallel.py
+++ b/gtest_parallel.py
@@ -580,6 +580,9 @@ def find_tests(binaries, additional_args, options, times):
     if options.gtest_filter != '':
       list_command += ['--gtest_filter=' + options.gtest_filter]
 
+    if options.size != '':
+      list_command += ['--size=' + options.size]
+
     try:
       test_list = subprocess.check_output(list_command,
                                           stderr=subprocess.STDOUT)
@@ -709,6 +712,8 @@ def default_options_parser():
                     help='color output')
   parser.add_option('--gtest_filter', type='string', default='',
                     help='test filter')
+  parser.add_option('--size', type='string', default='', 
+                    help='select a test size (S, M, L, XL, *) to run')
   parser.add_option('--gtest_also_run_disabled_tests', action='store_true',
                     default=False, help='run disabled tests too')
   parser.add_option('--print_test_times', action='store_true', default=False,


### PR DESCRIPTION
Update the `gtest-parallel` command-line parsing to match the nomenclature used in our test framework:
- Add a `--size` option
- Add a `--test` option in addition to `--gtest_filter`

Verified through manual testing.