### PR TITLE
script: Add aliases for repeat option

### DIFF
--- a/gtest_parallel.py
+++ b/gtest_parallel.py
@@ -884,7 +884,7 @@ def default_options_parser():
                          'available under gtest-parallel-logs/, so '
                          '--output_dir=/tmp will results in all logs being '
                          'available under /tmp/gtest-parallel-logs/.')
-  parser.add_option('-r', '--repeat', type='int', default=1,
+  parser.add_option('-r', '--repeat', '--loop', '--gtest_repeat', type='int', default=1,
                     help='Number of times to execute all the tests.')
   parser.add_option('--retry_failed', type='int', default=0,
                     help='Number of times to repeat failed tests.')


### PR DESCRIPTION
Add `--loop` and `--gtest_repeat` aliases to the `--repeat` option for the `gtest_parallel` script, matching syntax used elsewhere in our test frameworks. 

Snippet of `--help` output with these aliases:
```
Options:
  -h, --help            show this help message and exit
  -d OUTPUT_DIR, --output_dir=OUTPUT_DIR
                        Output directory for test logs. Logs will be available
                        under gtest-parallel-logs/, so --output_dir=/tmp will
                        results in all logs being available under /tmp/gtest-
                        parallel-logs/.
  -r REPEAT, --repeat=REPEAT, --loop=REPEAT, --gtest_repeat=REPEAT
                        Number of times to execute all the tests.
...
```

Tested locally with both options.