### PR TITLE
script: Force manual XML creation on task failure

### DIFF
--- a/gtest_parallel.py
+++ b/gtest_parallel.py
@@ -274,21 +274,33 @@ class XMLLogger(object):
   def __fetch_test_output(self, test_name, log_file):
     """
     Read from a test's log file and return all text after the initial
-    RUN preamble and OK / FAILED epilogues, if present
+    RUN preamble. Strip any status updates, summaries, etc. that do not
+    add useful information in this case
     """
     output = ""
     start_pattern = re.compile(".*\[ *RUN *\].*" + test_name)
     success_pattern = re.compile(".*\[ *OK *\].*" + test_name)
-    failure_pattern = re.compile(".*\[ *FAILED *\].*" + test_name)
+    passed_pattern = re.compile("\[ *PASSED *\]")
+    failure_pattern = re.compile("\[ *FAILED *\]")
+    size_pattern = re.compile("\[ *SIZE *\]")
+    status_pattern = re.compile(".*\[(=*|-*)\].*") # brackets with = or - symbols
+    summary_pattern = re.compile("[0-9]+ FAILED TEST")
+
     with open(log_file) as log:
       for line in log:
         if start_pattern.search(line.strip()) is not None:
           break
       for line in log:
+        if line == '\n': # skip lines that only contain linefeed
+          continue
         stripped = line.strip()
         if ((success_pattern.search(stripped) is not None) or 
-            (failure_pattern.search(stripped) is not None)):
-          break
+            (passed_pattern.search(stripped) is not None) or
+            (failure_pattern.search(stripped) is not None) or
+            (size_pattern.search(stripped) is not None) or 
+            (status_pattern.search(stripped) is not None) or 
+            (summary_pattern.search(stripped) is not None)): 
+          continue
         output += line
     return output
 

--- a/gtest_parallel.py
+++ b/gtest_parallel.py
@@ -274,7 +274,7 @@ class XMLLogger(object):
   def __fetch_test_output(self, test_name, log_file):
     """
     Read from a test's log file and return all text after the initial
-    RUN/OK/FAILED preamble
+    RUN preamble and OK / FAILED epilogues, if present
     """
     output = ""
     start_pattern = re.compile(".*\[ *RUN *\].*" + test_name)
@@ -341,18 +341,15 @@ class XMLLogger(object):
     it may not have generated valid XML. Handle this case by manually-constructing
     conformant XML from stdout/stderr output
     """
-    try:
-      return ET.parse(task.xml_file)
-    except:
-      xml = self.__generate_blank_xml(task.test_name, task.runtime_ms)
-      root = xml.getroot()
-      root.set('failures', '1')
-      suite = root.find('testsuite')
-      suite.set('failures', '1')
-      case = suite.find('testcase')
-      msg = self.__fetch_test_output(task.test_name, task.log_file)
-      ET.SubElement(case, 'failure', {'message': msg})
-      return xml
+    xml = self.__generate_blank_xml(task.test_name, task.runtime_ms)
+    root = xml.getroot()
+    root.set('failures', '1')
+    suite = root.find('testsuite')
+    suite.set('failures', '1')
+    case = suite.find('testcase')
+    msg = self.__fetch_test_output(task.test_name, task.log_file)
+    ET.SubElement(case, 'failure', {'message': msg})
+    return xml
 
   def __generate_new_xml(self, task, result):
     """
@@ -498,6 +495,7 @@ class TaskManager(object):
         result = TaskOutcome.TIMEOUT
       elif task.exit_code == 0:
         result = TaskOutcome.PASS
+
       self.xml_logger.log_xml(task, result)
       # Always remove temporary xml file
       # (these will be aggregated into one file)


### PR DESCRIPTION
I believe that this PR will fix the issue we were seeing with stack traces not being reported through Jenkins.

At present, we assume that if `googletest` generates an XML file for a given test, that file's contents are representative of the whole test _process_. This is not necessarily the case. 

If something happens in the test process _after_ the XML is generated but _before_ the process terminates, we will miss it. Logic in the script currently goes something like this:

```
- Did the test _process_ exit with a code other than zero?
  - If so: try to parse the XML generated by `googletest`
    - If valid XML wasn't generated (due to a crash, etc.), manually generate it from whatever was output to stdout/stderr
```

If the process exits with a non-zero exit code _after_ `googletest` registered the test as passing (say because of some issue during destruction/teardown), we will miss the error, because we parse the "passing" status generated by `googletest`. 

This PR updates the above logic to the following:

```
- Did the test _process_ exit with a code other than zero?
  - If so manually generate a failure in XML from whatever was output to stdout/stderr
```

This change should make the script more robust in handling crashes that occur while the test binary is being torn down.

As a side effect, this change will also group all failures into a single `<failure>` section. 

Testing: tested locally. 