### PR TITLE
john4744/1996_stack_trace

### DIFF
--- a/gtest_parallel.py
+++ b/gtest_parallel.py
@@ -350,7 +350,8 @@ class XMLLogger(object):
     suite.set('failures', '1')
     case = suite.find('testcase')
     timeout_state = {
-      'message': 'The test timed out after ' + str(task.runtime_ms / 1000.0) + ' seconds'
+      'message': 'The test timed out after ' + str(task.runtime_ms / 1000.0) + ' seconds\n\n'
+      + self.__fetch_test_output(task.test_name, task.log_file)
     }
     ET.SubElement(case, 'failure', timeout_state)
     return xml


### PR DESCRIPTION
If the test times out, grab the task's log and output it in the XML log. This is similar to how it's done when a test fails: https://github.com/Esri/gtest-parallel/blob/fa2b8591cf5edaca7bb760c33fddd706172b6e0b/gtest_parallel.py#L370-L371