### PR TITLE
john4744/2368_retain_flag

### DIFF
--- a/gtest_parallel.py
+++ b/gtest_parallel.py
@@ -861,7 +861,10 @@ def find_tests(binaries, additional_args, options, times):
     test_names = parse_test_names(test_binary, list_command, options.gtest_also_run_disabled_tests)
     for test_name in test_names:
       
-      test_command = command + ['--gtest_filter=' + test_name]
+      if options.test != '':
+        test_command = command + ['--test=' + test_name]
+      if options.gtest_filter != '':
+        test_command = command + ['--gtest_filter=' + test_name]
 
       # enforce timeout based on test size:
       # - if in S, append timeout = 60s

--- a/gtest_parallel.py
+++ b/gtest_parallel.py
@@ -860,11 +860,7 @@ def find_tests(binaries, additional_args, options, times):
     
     test_names = parse_test_names(test_binary, list_command, options.gtest_also_run_disabled_tests)
     for test_name in test_names:
-      
-      if options.test != '':
-        test_command = command + ['--test=' + test_name]
-      if options.gtest_filter != '':
-        test_command = command + ['--gtest_filter=' + test_name]
+      test_command = command + ['--test=' + test_name]
 
       # enforce timeout based on test size:
       # - if in S, append timeout = 60s


### PR DESCRIPTION
Issue: https://devtopia.esri.com/runtime/home-one/issues/2368
If `gtest-parallel` was called with `--test`, pass that along when running the executable.

3rdparty: https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-interface/382/downstreambuildview/
RTC: https://runtime-rtc.esri.com/view/vTest/job/vtest/job/runtimecore-interface/8769/downstreambuildview/