### PR TITLE
Resolve SyntaxWarnings in regexes

### DIFF
--- a/gtest_parallel.py
+++ b/gtest_parallel.py
@@ -301,12 +301,12 @@ class XMLLogger(object):
     add useful information in this case
     """
     output = ""
-    start_pattern = re.compile(".*[ *RUN *].*" + test_name)
-    success_pattern = re.compile(".*[ *OK *].*" + test_name)
-    passed_pattern = re.compile("[ *PASSED *]")
-    failure_pattern = re.compile("[ *FAILED *]")
-    size_pattern = re.compile("[ *SIZE *]")
-    status_pattern = re.compile(".*[(=*|-*)].*") # brackets with = or - symbols
+    start_pattern = re.compile(r".*\[ *RUN *\].*" + test_name)
+    success_pattern = re.compile(r".*\[ *OK *\].*" + test_name)
+    passed_pattern = re.compile(r"\[ *PASSED *\]")
+    failure_pattern = re.compile(r"\[ *FAILED *\]")
+    size_pattern = re.compile(r"\[ *SIZE *\]")
+    status_pattern = re.compile(r".*\[(=*|-*)\].*") # brackets with = or - symbols
     summary_pattern = re.compile("[0-9]+ FAILED TEST")
 
     with open(log_file) as log:

--- a/gtest_parallel.py
+++ b/gtest_parallel.py
@@ -301,12 +301,12 @@ class XMLLogger(object):
     add useful information in this case
     """
     output = ""
-    start_pattern = re.compile(".*\[ *RUN *\].*" + test_name)
-    success_pattern = re.compile(".*\[ *OK *\].*" + test_name)
-    passed_pattern = re.compile("\[ *PASSED *\]")
-    failure_pattern = re.compile("\[ *FAILED *\]")
-    size_pattern = re.compile("\[ *SIZE *\]")
-    status_pattern = re.compile(".*\[(=*|-*)\].*") # brackets with = or - symbols
+    start_pattern = re.compile(".*[ *RUN *].*" + test_name)
+    success_pattern = re.compile(".*[ *OK *].*" + test_name)
+    passed_pattern = re.compile("[ *PASSED *]")
+    failure_pattern = re.compile("[ *FAILED *]")
+    size_pattern = re.compile("[ *SIZE *]")
+    status_pattern = re.compile(".*[(=*|-*)].*") # brackets with = or - symbols
     summary_pattern = re.compile("[0-9]+ FAILED TEST")
 
     with open(log_file) as log:


### PR DESCRIPTION
Use of Python 3.12 flagged these as SyntaxWarnings at runtime:
```
09:34:52 /usr/local/rtc/python/3.12/bin/python /home/apptest/jenkins/workspace/vtest/runtimecore-linux/3rdparty/gtest-parallel/gtest-parallel /home/apptest/jenkins/workspace/vtest/runtimecore-linux/output/cmake_linux_x64/bin_test/geocontroller_tests --dump_xml_test_results=/home/apptest/jenkins/workspace/vtest/runtimecore-linux/results/geocontroller_tests_results_googletest.xml --test=* --size=* --data=/home/apptest/vtest/data 
09:34:52 /home/apptest/jenkins/workspace/vtest/runtimecore-linux/3rdparty/gtest-parallel/gtest_parallel.py:304: SyntaxWarning: invalid escape sequence '\['
09:34:52   start_pattern = re.compile(".*\[ *RUN *\].*" + test_name)
09:34:52 /home/apptest/jenkins/workspace/vtest/runtimecore-linux/3rdparty/gtest-parallel/gtest_parallel.py:305: SyntaxWarning: invalid escape sequence '\['
09:34:52   success_pattern = re.compile(".*\[ *OK *\].*" + test_name)
09:34:52 /home/apptest/jenkins/workspace/vtest/runtimecore-linux/3rdparty/gtest-parallel/gtest_parallel.py:306: SyntaxWarning: invalid escape sequence '\['
09:34:52   passed_pattern = re.compile("\[ *PASSED *\]")
09:34:52 /home/apptest/jenkins/workspace/vtest/runtimecore-linux/3rdparty/gtest-parallel/gtest_parallel.py:307: SyntaxWarning: invalid escape sequence '\['
09:34:52   failure_pattern = re.compile("\[ *FAILED *\]")
09:34:52 /home/apptest/jenkins/workspace/vtest/runtimecore-linux/3rdparty/gtest-parallel/gtest_parallel.py:308: SyntaxWarning: invalid escape sequence '\['
09:34:52   size_pattern = re.compile("\[ *SIZE *\]")
09:34:52 /home/apptest/jenkins/workspace/vtest/runtimecore-linux/3rdparty/gtest-parallel/gtest_parallel.py:309: SyntaxWarning: invalid escape sequence '\['
09:34:52   status_pattern = re.compile(".*\[(=*|-*)\].*") # brackets with = or - symbols
```

3rdparty build (includes 1 other 3rdparty lib to trigger the job to complete): https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-interface/1177/downstreambuildview/
RTC test: https://runtime-rtc.esri.com/view/vTest/job/vtest/job/runtimecore-interface/27914/downstreambuildview/