### PR TITLE
only add specific sized test to map

### DIFF
--- a/gtest_parallel.py
+++ b/gtest_parallel.py
@@ -837,9 +837,9 @@ def find_tests(binaries, additional_args, options, times):
   for test_binary in binaries:
 
     # build dict of test size -> test names for each binary
-    test_sizes_command = [test_binary] + additional_args
     test_sizes = {'s': [], 'm': [], 'l':[], 'x': []}
     for size in test_sizes.keys():
+      test_sizes_command = [test_binary] + additional_args
       test_sizes_command += ['--size=' + size]
       test_sizes_command += ['--gtest_list_tests']
       test_sizes[size] = parse_test_names(test_binary, test_sizes_command, options.gtest_also_run_disabled_tests)


### PR DESCRIPTION
I noticed that the timeouts were not respected for small size. This was because when creating the map<size, [test_names]>, the command to filter testnames by sizes was appended without clearing, resulting in `test Medium array = tests Small + test Medium`, same for other sizes.
This was affecting line 871 which would result a small test to be listed in medium array and then its timeout being replaced by the medium